### PR TITLE
Added client functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ Role Variables
 
 Dependencies
 ------------
+requirements.yaml:
+
+```yaml---
+collections:
+- community.network
+```
 
 Install using:
 
-- `ansible-galaxy -r requirements.yaml install`
+- `ansible-galaxy collection install -r requirements.yaml`
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Role Variables
 Dependencies
 ------------
 
-`ansible-galaxy collection install community.network`
+Install using:
+
+- `ansible-galaxy -r requirements.yaml install`
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Vyatta based units (Vyatta, EdgeOS, VyOS)
 Role Variables
 --------------
 
-`wireguard_url` (default: `https://api.github.com/repos/Lochnair/vyatta-wireguard/releases`)
+`wireguard_url` (default: `https://api.github.com/repos/WireGuard/wireguard-vyatta-ubnt/releases`)
 
-`wireguard_release` (default: `0.0.20191012-1`)
+`wireguard_release` (default: `1.0.20210424-1`)
 
 `wireguard_config_dir` (default: `/config/wireguard`)
 
@@ -29,7 +29,7 @@ Role Variables
 Dependencies
 ------------
 
-None
+`ansible-galaxy collection install community.network`
 
 Example Playbook
 ----------------
@@ -54,16 +54,18 @@ Playbook to run against EdgeOS routers.
   vars:
     ansible_network_os: edgeos
     wireguard_install: false
-    wireguard_configure: true
+    wireguard_configure: "server"  # change to "client" for client
     wireguard_wg_interfaces:
       - interface: wg0
         description: "VPN Clients"
         address: 192.168.58.1/24
-        port: 51820
+        # privkey: <private key> assign private key with a variable instead of a file for client
+        port: 51820 # client doesn't use port
         peer:
           - id: "AAAAAAAAAABBBBBBBBBBCCCCCCCCCCCCDDDDDDDDDDD="
             description: "peer 1"
             allowed_ips: 192.168.53.101/32
+            # endpoint: <IP of server>:<port>  # client needs an endpoint as well
   roles:
     - ansible-role-wireguard-vyatta
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for ansible-role-wireguard-vyatta
 
-wireguard_url: https://api.github.com/repos/Lochnair/vyatta-wireguard/releases
-wireguard_release: 0.0.20191012-1
+wireguard_url: https://api.github.com/repos/WireGuard/wireguard-vyatta-ubnt/releases
+wireguard_release: 1.0.20210424-1
 wireguard_config_dir: /config/wireguard
 
 wireguard_hardware:

--- a/tasks/cli-config-client.yml
+++ b/tasks/cli-config-client.yml
@@ -1,0 +1,28 @@
+---
+- name: Gather facts for play
+  edgeos_facts:
+    gather_subset: "!config"
+
+- name: Configure wireguard client interface settings
+  edgeos_config:
+    lines:
+      - "set interfaces wireguard {{ item.interface }} address {{ item.address }}"
+      - "set interfaces wireguard {{ item.interface }} private-key {{ item.privkey }}"
+      - "set interfaces wireguard {{ item.interface }} description '{{ item.description }}'"
+  loop: "{{ wireguard_wg_interfaces | flatten(levels=1) }}"
+  loop_control:
+    label: "{{ item.interface }}"
+  when: ("EdgeRouter" in ansible_facts['net_model']) or
+        ("UniFi" in ansible_facts['net_model'])
+
+- name: Configure wireguard client peer
+  edgeos_config:
+    lines:
+      - "set interfaces wireguard {{ item.0.interface }} peer {{ item.1.id }} description {{ item.1.description }}"
+      - "set interfaces wireguard {{ item.0.interface }} peer {{ item.1.id }} allowed-ips {{ item.1.allowed_ips }}"
+      - "set interfaces wireguard {{ item.0.interface }} peer {{ item.1.id }} endpoint {{ item.1.endpoint }}"
+  loop: "{{ wireguard_wg_interfaces | subelements('peer') }}"
+  loop_control:
+    label: "{{ item.1.description }}"
+  when: ("EdgeRouter" in ansible_facts['net_model']) or
+        ("UniFi" in ansible_facts['net_model'])

--- a/tasks/cli-config-client.yml
+++ b/tasks/cli-config-client.yml
@@ -3,6 +3,16 @@
   edgeos_facts:
     gather_subset: "!config"
 
+- name: Delete existing interface(s)
+  edgeos_config:
+    lines:
+      - "delete interfaces wireguard {{ item.interface }}"
+  loop: "{{ wireguard_wg_interfaces | flatten(levels=1) }}"
+  loop_control:
+    label: "{{ item.interface }}"
+  when: ("EdgeRouter" in ansible_facts['net_model']) or
+        ("UniFi" in ansible_facts['net_model'])
+
 - name: Configure wireguard client interface settings
   edgeos_config:
     lines:
@@ -22,7 +32,9 @@
       - "set interfaces wireguard {{ item.0.interface }} peer {{ item.1.id }} allowed-ips {{ item.1.allowed_ips }}"
       - "set interfaces wireguard {{ item.0.interface }} peer {{ item.1.id }} endpoint {{ item.1.endpoint }}"
   loop: "{{ wireguard_wg_interfaces | subelements('peer') }}"
+  # include_tasks: allowed-ips.yml
   loop_control:
     label: "{{ item.1.description }}"
   when: ("EdgeRouter" in ansible_facts['net_model']) or
         ("UniFi" in ansible_facts['net_model'])
+

--- a/tasks/cli-config-server.yml
+++ b/tasks/cli-config-server.yml
@@ -3,6 +3,16 @@
   edgeos_facts:
     gather_subset: "!config"
 
+- name: Delete existing interface(s)
+  edgeos_config:
+    lines:
+      - "delete interfaces wireguard {{ item.interface }}"
+  loop: "{{ wireguard_wg_interfaces | flatten(levels=1) }}"
+  loop_control:
+    label: "{{ item.interface }}"
+  when: ("EdgeRouter" in ansible_facts['net_model']) or
+        ("UniFi" in ansible_facts['net_model'])
+
 - name: Configure wireguard server interface settings
   edgeos_config:
     lines:

--- a/tasks/cli-config-server.yml
+++ b/tasks/cli-config-server.yml
@@ -3,7 +3,7 @@
   edgeos_facts:
     gather_subset: "!config"
 
-- name: Configure basic wireguard settings
+- name: Configure wireguard server interface settings
   edgeos_config:
     lines:
       - "set interfaces wireguard {{ item.interface }} address {{ item.address }}"
@@ -16,7 +16,7 @@
   when: ("EdgeRouter" in ansible_facts['net_model']) or
         ("UniFi" in ansible_facts['net_model'])
 
-- name: Configure wireguard peers
+- name: Configure wireguard server peer(s)
   edgeos_config:
     lines:
       - "set interfaces wireguard {{ item.0.interface }} peer {{ item.1.id }} description {{ item.1.description }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,12 @@
   when:
     - wireguard_install
 
-- name: Configure wireguard
-  include_tasks: cli-config.yml
+- name: Configure wireguard server
+  include_tasks: cli-config-server.yml
   when:
-    - wireguard_configure
+    - wireguard_configure == "server"
+
+- name: Configure wireguard client
+  include_tasks: cli-config-client.yml
+  when:
+    - wireguard_configure == "client"


### PR DESCRIPTION
Things I would like to change/fix but I don't know how because I'm new to ansible:
1. I want to make it an option to use the file or a variable for the keys.  Right now the client config only uses a variable and the server only allows a file.  ( I could do this by adding 2 more cli-config files and an associated variable but there is probably a better way?)

2.  The config doesn't work right after the install. In particular it's the edgeos_facts. So I currently run them seperately.

I would like to do these before the merge